### PR TITLE
chore 🔧 remove caret for fixed dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# git diff
+diff.txt

--- a/package.json
+++ b/package.json
@@ -12,29 +12,29 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
-		"@prisma/client": "^5.20.0",
-		"@radix-ui/react-slot": "^1.1.0",
-		"class-variance-authority": "^0.7.0",
-		"clsx": "^2.1.1",
-		"lucide-react": "^0.451.0",
+		"@prisma/client": "5.20.0",
+		"@radix-ui/react-slot": "1.1.0",
+		"class-variance-authority": "0.7.0",
+		"clsx": "2.1.1",
+		"lucide-react": "0.451.0",
 		"next": "14.2.15",
-		"react": "^18",
-		"react-dom": "^18",
-		"tailwind-merge": "^2.5.3",
-		"tailwindcss-animate": "^1.0.7"
+		"react": "18",
+		"react-dom": "18",
+		"tailwind-merge": "2.5.3",
+		"tailwindcss-animate": "1.0.7"
 	},
 	"devDependencies": {
-		"@types/node": "^20",
-		"@types/react": "^18",
-		"@types/react-dom": "^18",
-		"eslint": "^8",
+		"@types/node": "20",
+		"@types/react": "18",
+		"@types/react-dom": "18",
+		"eslint": "8",
 		"eslint-config-next": "14.2.15",
-		"eslint-config-prettier": "^9.1.0",
-		"postcss": "^8",
-		"prettier": "^3.3.3",
-		"prisma": "^5.20.0",
-		"tailwindcss": "^3.4.1",
-		"ts-node": "^10.9.2",
-		"typescript": "^5"
+		"eslint-config-prettier": "9.1.0",
+		"postcss": "8",
+		"prettier": "3.3.3",
+		"prisma": "5.20.0",
+		"tailwindcss": "3.4.1",
+		"ts-node": "10.9.2",
+		"typescript": "5"
 	}
 }


### PR DESCRIPTION
- Removed carets (^) from dependencies in `package.json` to avoid automatic updates and keep versions fixed.
- Updated `.gitignore` to include `diff.txt`.