### PR TITLE
feat: add image size limit

### DIFF
--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -95,10 +95,10 @@ function MainForm() {
 	const onDrop = (acceptedFiles: any) => {
 		if (acceptedFiles[0].size >= 10000000) {
 			setImageError(
-				`Maximo 10 MB, Tu archivo pesa ${(acceptedFiles[0].size / 1_000_000).toFixed(1)}`,
+				`Máximo 10 MB, tu archivo pesa ${(acceptedFiles[0].size / 1_000_000).toFixed(1)}`,
 			)
 			errorToast(
-				`Maximo 10 MB, Tu archivo pesa ${(acceptedFiles[0].size / 1_000_000).toFixed(1)}`,
+				`Máximo 10 MB, tu archivo pesa ${(acceptedFiles[0].size / 1_000_000).toFixed(1)}`,
 			)
 			return
 		}

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -93,6 +93,15 @@ function MainForm() {
 	const setData = useImageStore((state) => state.setData)
 
 	const onDrop = (acceptedFiles: any) => {
+		if (acceptedFiles[0].size >= 10000000) {
+			setImageError(
+				`Maximo 10 MB, Tu archivo pesa ${(acceptedFiles[0].size / 1_000_000).toFixed(1)}`,
+			)
+			errorToast(
+				`Maximo 10 MB, Tu archivo pesa ${(acceptedFiles[0].size / 1_000_000).toFixed(1)}`,
+			)
+			return
+		}
 		if (acceptedFiles.length > 1) {
 			setImageError('Solo puedes seleccionar 1 imagen')
 			errorToast('Solo puedes seleccionar 1 imagen')


### PR DESCRIPTION
El plan free de cloudinary no soporta subir imagenes de **10 MB**
```
{
  message: 'File size too large. Got 11926513. Maximum is 10485760. Upgrade your plan to enjoy higher limits https://www.cloudinary.com/pricing/upgrades/file-limit',
  name: 'Error',
  http_code: 400
}

```

Agregue un límite en el componente Form.tsx
